### PR TITLE
feat: 添加.onPermissionRequest属性来通知用户收到获取权限请求，并根据权限请求类型显示弹框内容

### DIFF
--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -387,14 +387,14 @@ export struct RNCWebView {
     try {
       bundleManager.getBundleInfoForSelf(bundleFlags, (error, data) => {
         if (error) {
-          Logger.debug(TAG,
+          Logger.error(TAG,
             `[RNOH] getBundleInfoForSelf failed ErrorCode: ${error.code},  Message: ${error.message}`);
         } else {
           this.bundleName = JSON.stringify(data.name)
         }
       });
     } catch (error) {
-      Logger.debug(TAG,
+      Logger.error(TAG,
         `[RNOH] getBundleInfoForSelf failed ErrorCode: ${error.code},  Message: ${error.message}`);
     }
   }
@@ -405,7 +405,6 @@ export struct RNCWebView {
 
   getPermissionDialogMessage(event:OnPermissionRequestEvent) {
     let permissionDialogMessage = ''
-    console.info("=======eee==",event.request.getAccessibleResource().toString())
     if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.VIDEO_CAPTURE)){
       permissionDialogMessage = this.resourceToString($r('app.string.useYourCamera'))
     }else if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.AUDIO_CAPTURE)){

--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -405,11 +405,12 @@ export struct RNCWebView {
 
   getPermissionDialogMessage(event:OnPermissionRequestEvent) {
     let permissionDialogMessage = ''
+    console.info("=======eee==",event.request.getAccessibleResource().toString())
     if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.VIDEO_CAPTURE)){
       permissionDialogMessage = this.resourceToString($r('app.string.useYourCamera'))
     }else if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.AUDIO_CAPTURE)){
       permissionDialogMessage = this.resourceToString($r('app.string.useYourMicrophone'))
-    }else if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.VIDEO_CAPTURE)){
+    }else if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.MidiSysex)){
       permissionDialogMessage = this.resourceToString($r('app.string.MIDI_SYSEX_Resources'))
     }
     return permissionDialogMessage;

--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -40,6 +40,7 @@ import {
   WebViewOverScrollMode,
   ZERO
 } from './Magic';
+import { bundleManager } from '@kit.AbilityKit';
 
 export const TAG = "WebView"
 
@@ -67,6 +68,7 @@ export struct RNCWebView {
   cacheMode: number = CacheMode.Default;
   lockIdentifier: string = "";
   requestUrl: string = "";
+  bundleName: string = "";
   messagingEnabled: boolean = false;
   hasRegisterJavaScriptProxy: boolean = false;
   controllerAttached: boolean = false;
@@ -90,6 +92,7 @@ export struct RNCWebView {
   aboutToAppear() {
     try {
       this.initVariable()
+      this.getPermissionDialogTitle()
       this.url = this.source.uri as string;
       webview.WebviewController.setWebDebuggingAccess(this.descriptorWrapper.props.webviewDebuggingEnabled)
       this.cleanUpCallbacks.push(this.ctx.descriptorRegistry.subscribeToDescriptorChanges(this.tag,
@@ -376,9 +379,70 @@ export struct RNCWebView {
     }
   }
 
+  getPermissionDialogTitle() {
+    let bundleFlags =
+      bundleManager.BundleFlag.GET_BUNDLE_INFO_WITH_HAP_MODULE | bundleManager.BundleFlag.GET_BUNDLE_INFO_WITH_ABILITY |
+      bundleManager.BundleFlag.GET_BUNDLE_INFO_WITH_REQUESTED_PERMISSION;
+
+    try {
+      bundleManager.getBundleInfoForSelf(bundleFlags, (error, data) => {
+        if (error) {
+          Logger.debug(TAG,
+            `[RNOH] getBundleInfoForSelf failed ErrorCode: ${error.code},  Message: ${error.message}`);
+        } else {
+          this.bundleName = JSON.stringify(data.name)
+        }
+      });
+    } catch (error) {
+      Logger.debug(TAG,
+        `[RNOH] getBundleInfoForSelf failed ErrorCode: ${error.code},  Message: ${error.message}`);
+    }
+  }
+
+  resourceToString(resource:Resource):string{
+    return getContext(this).resourceManager.getStringSync(resource)
+  }
+
+  getPermissionDialogMessage(event:OnPermissionRequestEvent) {
+    let permissionDialogMessage = ''
+    if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.VIDEO_CAPTURE)){
+      permissionDialogMessage = this.resourceToString($r('app.string.useYourCamera'))
+    }else if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.AUDIO_CAPTURE)){
+      permissionDialogMessage = this.resourceToString($r('app.string.useYourMicrophone'))
+    }else if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.VIDEO_CAPTURE)){
+      permissionDialogMessage = this.resourceToString($r('app.string.MIDI_SYSEX_Resources'))
+    }
+    return permissionDialogMessage;
+  }
+
   build() {
     Stack() {
       Web({ src: "", controller: this.controller, renderMode: this.renderMode })
+        .onPermissionRequest((event) => {
+          if (event) {
+            AlertDialog.show({
+              title: this.resourceToString($r('app.string.onConfirm')) + this.bundleName,
+              message: this.getPermissionDialogMessage(event),
+              alignment: DialogAlignment.Center,
+              primaryButton: {
+                value: $r('app.string.deny'),
+                action: () => {
+                  event.request.deny();
+                }
+              },
+              secondaryButton: {
+                value: $r('app.string.onConfirm'),
+                action: () => {
+                  event.request.grant(event.request.getAccessibleResource());
+                }
+              },
+              cancel: () => {
+                event.request.deny();
+              }
+            })
+          }
+        })
+
         .width(this.webviewWidth)
         .height(this.webviewHeight)
         .fileAccess(this.allowFileAccess)

--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -92,7 +92,7 @@ export struct RNCWebView {
   aboutToAppear() {
     try {
       this.initVariable()
-      this.getPermissionDialogTitle()
+      this.getBundleName()
       this.url = this.source.uri as string;
       webview.WebviewController.setWebDebuggingAccess(this.descriptorWrapper.props.webviewDebuggingEnabled)
       this.cleanUpCallbacks.push(this.ctx.descriptorRegistry.subscribeToDescriptorChanges(this.tag,
@@ -379,7 +379,7 @@ export struct RNCWebView {
     }
   }
 
-  getPermissionDialogTitle() {
+  getBundleName() {
     let bundleFlags =
       bundleManager.BundleFlag.GET_BUNDLE_INFO_WITH_HAP_MODULE | bundleManager.BundleFlag.GET_BUNDLE_INFO_WITH_ABILITY |
       bundleManager.BundleFlag.GET_BUNDLE_INFO_WITH_REQUESTED_PERMISSION;
@@ -405,12 +405,17 @@ export struct RNCWebView {
 
   getPermissionDialogMessage(event:OnPermissionRequestEvent) {
     let permissionDialogMessage = ''
-    if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.VIDEO_CAPTURE)){
-      permissionDialogMessage = this.resourceToString($r('app.string.useYourCamera'))
-    }else if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.AUDIO_CAPTURE)){
-      permissionDialogMessage = this.resourceToString($r('app.string.useYourMicrophone'))
-    }else if(event.request.getAccessibleResource().toString().includes(ProtectedResourceType.MidiSysex)){
-      permissionDialogMessage = this.resourceToString($r('app.string.MIDI_SYSEX_Resources'))
+    permissionDialogMessage = event.request.getAccessibleResource().toString()
+    switch (permissionDialogMessage) {
+      case (ProtectedResourceType.VIDEO_CAPTURE + "," + ProtectedResourceType.AUDIO_CAPTURE):
+        permissionDialogMessage = this.resourceToString($r('app.string.use_your_camera'))
+        break;
+      case ProtectedResourceType.AUDIO_CAPTURE:
+        permissionDialogMessage = this.resourceToString($r('app.string.use_your_microphone'))
+        break;
+      case ProtectedResourceType.MidiSysex:
+        permissionDialogMessage = this.resourceToString($r('app.string.midi_sysex_resources'))
+        break;
     }
     return permissionDialogMessage;
   }
@@ -421,7 +426,7 @@ export struct RNCWebView {
         .onPermissionRequest((event) => {
           if (event) {
             AlertDialog.show({
-              title: this.resourceToString($r('app.string.onConfirm')) + this.bundleName,
+              title: this.resourceToString($r('app.string.on_confirm')) + this.bundleName,
               message: this.getPermissionDialogMessage(event),
               alignment: DialogAlignment.Center,
               primaryButton: {
@@ -431,7 +436,7 @@ export struct RNCWebView {
                 }
               },
               secondaryButton: {
-                value: $r('app.string.onConfirm'),
+                value: $r('app.string.on_confirm'),
                 action: () => {
                   event.request.grant(event.request.getAccessibleResource());
                 }

--- a/harmony/rn_webview/src/main/resources/base/element/string.json
+++ b/harmony/rn_webview/src/main/resources/base/element/string.json
@@ -14,15 +14,15 @@
     },
     {
       "name": "use_your_camera",
-      "value": "使用你的相机 ？ "
+      "value": "使用你的相机？"
     },
     {
       "name": "use_your_microphone",
-      "value": "使用你的麦克风 ？ "
+      "value": "使用你的麦克风？"
     },
     {
       "name": "midi_sysex_resources",
-      "value": "访问MIDI SYSEX 资源 ？ "
+      "value": "访问 MIDI SYSEX 资源？"
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/base/element/string.json
+++ b/harmony/rn_webview/src/main/resources/base/element/string.json
@@ -9,20 +9,20 @@
       "value":"不允许"
     },
     {
-      "name":"onConfirm",
+      "name":"on_confirm",
       "value":"允许"
     },
     {
-      "name": "useYourCamera",
-      "value": "使用你的相机？ "
+      "name": "use_your_camera",
+      "value": "使用你的相机 ？ "
     },
     {
-      "name": "useYourMicrophone",
-      "value": "使用你的麦克风？ "
+      "name": "use_your_microphone",
+      "value": "使用你的麦克风 ？ "
     },
     {
-      "name": "MIDI_SYSEX_Resources",
-      "value": "访问MIDI SYSEX 资源？ "
+      "name": "midi_sysex_resources",
+      "value": "访问MIDI SYSEX 资源 ？ "
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/base/element/string.json
+++ b/harmony/rn_webview/src/main/resources/base/element/string.json
@@ -3,6 +3,26 @@
     {
       "name":"page_show",
       "value":"page from npm package"
+    },
+    {
+      "name":"deny",
+      "value":"不允许"
+    },
+    {
+      "name":"onConfirm",
+      "value":"允许"
+    },
+    {
+      "name": "useYourCamera",
+      "value": "使用你的相机？"
+    },
+    {
+      "name": "useYourMicrophone",
+      "value": "使用你的麦克风？"
+    },
+    {
+      "name": "MIDI_SYSEX_Resources",
+      "value": "访问MIDI SYSEX 资源？"
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/base/element/string.json
+++ b/harmony/rn_webview/src/main/resources/base/element/string.json
@@ -14,11 +14,11 @@
     },
     {
       "name": "useYourCamera",
-      "value": "使用你的相机？"
+      "value": "使用你的相机？ "
     },
     {
       "name": "useYourMicrophone",
-      "value": "使用你的麦克风？"
+      "value": "使用你的麦克风？ "
     },
     {
       "name": "MIDI_SYSEX_Resources",

--- a/harmony/rn_webview/src/main/resources/base/element/string.json
+++ b/harmony/rn_webview/src/main/resources/base/element/string.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "MIDI_SYSEX_Resources",
-      "value": "访问MIDI SYSEX 资源？"
+      "value": "访问MIDI SYSEX 资源？ "
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/en_US/element/string.json
+++ b/harmony/rn_webview/src/main/resources/en_US/element/string.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "MIDI_SYSEX_Resources",
-      "value": " MIDI SYSEX Resources？"
+      "value": " MIDI SYSEX Resources? "
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/en_US/element/string.json
+++ b/harmony/rn_webview/src/main/resources/en_US/element/string.json
@@ -14,11 +14,11 @@
     },
     {
       "name": "useYourCamera",
-      "value": "useYourCamera?"
+      "value": "useYourCamera? "
     },
     {
       "name": "useYourMicrophone",
-      "value": "useYourMicrophone?"
+      "value": "useYourMicrophone? "
     },
     {
       "name": "MIDI_SYSEX_Resources",

--- a/harmony/rn_webview/src/main/resources/en_US/element/string.json
+++ b/harmony/rn_webview/src/main/resources/en_US/element/string.json
@@ -14,15 +14,15 @@
     },
     {
       "name": "use_your_camera",
-      "value": "use Your Camera ? "
+      "value": "use Your Camera?"
     },
     {
       "name": "use_your_microphone",
-      "value": "use your microphone ? "
+      "value": "use your microphone?"
     },
     {
       "name": "midi_sysex_resources",
-      "value": "MIDI SYSEX Resources ? "
+      "value": "MIDI SYSEX Resources?"
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/en_US/element/string.json
+++ b/harmony/rn_webview/src/main/resources/en_US/element/string.json
@@ -9,20 +9,20 @@
       "value":"deny"
     },
     {
-      "name":"onConfirm",
-      "value":"onConfirm"
+      "name":"on_confirm",
+      "value":"on confirm"
     },
     {
-      "name": "useYourCamera",
-      "value": "useYourCamera? "
+      "name": "use_your_camera",
+      "value": "use Your Camera ? "
     },
     {
-      "name": "useYourMicrophone",
-      "value": "useYourMicrophone? "
+      "name": "use_your_microphone",
+      "value": "use your microphone ? "
     },
     {
-      "name": "MIDI_SYSEX_Resources",
-      "value": " MIDI SYSEX Resources? "
+      "name": "midi_sysex_resources",
+      "value": "MIDI SYSEX Resources ? "
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/en_US/element/string.json
+++ b/harmony/rn_webview/src/main/resources/en_US/element/string.json
@@ -3,6 +3,26 @@
     {
       "name":"page_show",
       "value":"page from npm package"
+    },
+    {
+      "name":"deny",
+      "value":"deny"
+    },
+    {
+      "name":"onConfirm",
+      "value":"onConfirm"
+    },
+    {
+      "name": "useYourCamera",
+      "value": "useYourCamera?"
+    },
+    {
+      "name": "useYourMicrophone",
+      "value": "useYourMicrophone?"
+    },
+    {
+      "name": "MIDI_SYSEX_Resources",
+      "value": " MIDI SYSEX Resources？"
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
+++ b/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
@@ -14,11 +14,11 @@
     },
     {
       "name": "useYourCamera",
-      "value": "使用你的相机？"
+      "value": "使用你的相机？ "
     },
     {
       "name": "useYourMicrophone",
-      "value": "使用你的麦克风？"
+      "value": "使用你的麦克风？ "
     },
     {
       "name": "MIDI_SYSEX_Resources",

--- a/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
+++ b/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
@@ -3,6 +3,26 @@
     {
       "name":"page_show",
       "value":"page from npm package"
+    },
+    {
+      "name":"deny",
+      "value":"不允许"
+    },
+    {
+      "name": "onConfirm",
+      "value": "允许"
+    },
+    {
+      "name": "useYourCamera",
+      "value": "使用你的相机？"
+    },
+    {
+      "name": "useYourMicrophone",
+      "value": "使用你的麦克风？"
+    },
+    {
+      "name": "MIDI_SYSEX_Resources",
+      "value": "访问MIDI SYSEX 资源？"
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
+++ b/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
@@ -9,20 +9,20 @@
       "value":"不允许"
     },
     {
-      "name": "onConfirm",
+      "name": "on_confirm",
       "value": "允许"
     },
     {
-      "name": "useYourCamera",
-      "value": "使用你的相机？ "
+      "name": "use_your_camera",
+      "value": "使用你的相机 ？ "
     },
     {
-      "name": "useYourMicrophone",
-      "value": "使用你的麦克风？ "
+      "name": "use_your_microphone",
+      "value": "使用你的麦克风 ？ "
     },
     {
-      "name": "MIDI_SYSEX_Resources",
-      "value": "访问MIDI SYSEX 资源？ "
+      "name": "midi_sysex_resources",
+      "value": "访问 MIDI SYSEX 资源 ？ "
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
+++ b/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "MIDI_SYSEX_Resources",
-      "value": "访问MIDI SYSEX 资源？"
+      "value": "访问MIDI SYSEX 资源？ "
     }
   ]
 }

--- a/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
+++ b/harmony/rn_webview/src/main/resources/zh_CN/element/string.json
@@ -14,15 +14,15 @@
     },
     {
       "name": "use_your_camera",
-      "value": "使用你的相机 ？ "
+      "value": "使用你的相机？"
     },
     {
       "name": "use_your_microphone",
-      "value": "使用你的麦克风 ？ "
+      "value": "使用你的麦克风？"
     },
     {
       "name": "midi_sysex_resources",
-      "value": "访问 MIDI SYSEX 资源 ？ "
+      "value": "访问 MIDI SYSEX 资源？"
     }
   ]
 }


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

添加.onPermissionRequest属性来通知用户收到获取权限请求，并根据权限请求类型显示弹框内容,如相机权限，麦克风权限等

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
测试场景：
1. 需要编写网页内请求开启相机/麦克风权限代码index.html
2. 通过http-server部署index.html
3. webView库demo中将 source={{ uri: "http://127.0.0.1:8080"}}
4. rnoh工程需要申请相机/麦克风系统权限
5. 验证效果如下视频
https://github.com/user-attachments/assets/c55dd2a4-4b55-4734-a13e-d971f207d93b

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
