### PR TITLE
fix:处理深色模式权重和安卓不一致

### DIFF
--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -400,7 +400,7 @@ export struct RNCWebView {
         .verticalScrollBarAccess(this.descriptorWrapper.rawProps.showsVerticalScrollIndicator)
         .overviewModeAccess(this.descriptorWrapper.rawProps.scalesPageToFit)
         .textZoomRatio(this.descriptorWrapper.rawProps.textZoom)
-        .darkMode(this.descriptorWrapper.rawProps.forceDarkOn ? WebDarkMode.On : WebDarkMode.Auto)
+        .darkMode(BaseOperate.getColorMode(this.ctx.uiAbilityContext, this.descriptorWrapper.rawProps.forceDarkOn))
         .forceDarkAccess(this.forceDark)
         .cacheMode(this.cacheMode)
         .minFontSize(this.minFontSize)

--- a/harmony/rn_webview/src/main/ets/WebViewBaseOperate.ets
+++ b/harmony/rn_webview/src/main/ets/WebViewBaseOperate.ets
@@ -2,6 +2,7 @@ import { RNC } from '@rnoh/react-native-openharmony/generated/ts'
 import { webview } from '@kit.ArkWeb'
 import { CACHE_MODE, COMMAND_NAME, ONE_HUNDRED, WebViewEventParams } from './Magic';
 import Logger from './Logger';
+import { common, ConfigurationConstant } from '@kit.AbilityKit';
 
 export const TAG = "WebView"
 
@@ -30,6 +31,16 @@ export class BaseOperate {
       webview.WebCookieManager.putAcceptThirdPartyCookieEnabled(status);
     } catch (error) {
       Logger.error(TAG, `[RNOH] setThirdPartyCookiesEnabled Errorcode: ${error.code}`);
+    }
+  }
+
+  static getColorMode(context: common.UIAbilityContext, forceDarkOn: boolean): WebDarkMode {
+    try {
+      return ((context.config.colorMode === ConfigurationConstant.ColorMode.COLOR_MODE_DARK) && forceDarkOn) ?
+      WebDarkMode.On : WebDarkMode.Off
+    } catch (error) {
+      Logger.error(TAG, `[RNOH] getColorMode Errorcode: ${error.code}`);
+      return WebDarkMode.Off
     }
   }
 


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- close #228  


## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

无

## Checklist


- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

