### PR TITLE
feat: implement onShouldStartLoadWithRequest and webView turboModule

### DIFF
--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -74,7 +74,6 @@ export struct RNCWebView {
   overScrollMode: OverScrollMode = OverScrollMode.NEVER;
   progress: number = ZERO;
   cacheMode: number = CacheMode.Default;
-  lockIdentifier: string = "";
   requestUrl: string = "";
   bundleName: string = "";
   messagingEnabled: boolean = false;
@@ -99,6 +98,7 @@ export struct RNCWebView {
   private descriptorWrapper: WebViewDescriptor = Object() as WebViewDescriptor
   private webViewBaseOperate: BaseOperate | null = null
   private shouldInterceptLoad: boolean = true
+  private callLoadTimer: number = -1
   static readonly SHOULD_OVERRIDE_URL_LOADING_TIMEOUT: number = 250
 
   aboutToAppear() {
@@ -264,7 +264,7 @@ export struct RNCWebView {
   controllerAttachedInit(): void {
     this.controllerAttached = true;
     this.eventEmitter = new RNC.RNCWebView.EventEmitter(this.ctx.rnInstance, this.tag)
-    this.webViewBaseOperate = new BaseOperate(this.tag, this.eventEmitter, this.controller)
+    this.webViewBaseOperate = new BaseOperate(this.eventEmitter, this.controller)
     this.webViewBaseOperate.setCustomUserAgent(this.descriptorWrapper.rawProps.userAgent,
       this.descriptorWrapper.rawProps.applicationNameForUserAgent)
     this.webViewBaseOperate.setFraudulentWebsiteWarningEnabled(this.descriptorWrapper.rawProps.fraudulentWebsiteWarningEnabled)
@@ -272,7 +272,7 @@ export struct RNCWebView {
     let uri = this.source.uri
     if (this.source.html != undefined && this.source.html != "") {
       try {
-        this.shouldInterceptLoad = true
+        this.resetIntercept()
         this.controller.loadData(
           this.source.html,
           "text/html",
@@ -284,10 +284,10 @@ export struct RNCWebView {
         Logger.error(TAG, "error:" + error)
       }
     } else if (uri != undefined && uri != "") {
-      this.shouldInterceptLoad = true
+      this.resetIntercept()
       this.controller.loadUrl(uri, this.headers);
     } else {
-      this.shouldInterceptLoad = true
+      this.resetIntercept()
       this.controller.loadUrl(uri, this.headers);
     }
     if (!this.hasRegisterJavaScriptProxy) {
@@ -358,19 +358,22 @@ export struct RNCWebView {
   }
 
   onLoadIntercept(event: OnLoadInterceptEvent): boolean {
+    Logger.debug(TAG, `onLoadIntercept request url:${event.data.getRequestUrl()} ,shouldInterceptLoad:${this.shouldInterceptLoad}`)
     if (!this.shouldInterceptLoad) {
       return false
     }
 
+    let lockIdentifier = this.webViewBaseOperate?.getLockIdentifier()
     let webViewTurboModule = this.ctx.rnInstance.getUITurboModule<WebViewTurboModule>(TM.RNCWebViewModule.NAME)
-    let timer = setTimeout(()=>{
-      webViewTurboModule.callLoadFunction(this.tag)
+    this.callLoadTimer = setTimeout(()=>{
+      Logger.debug(TAG, "call setTimeout")
+      webViewTurboModule.callLoadFunction(lockIdentifier)
     }, RNCWebView.SHOULD_OVERRIDE_URL_LOADING_TIMEOUT)
 
-    webViewTurboModule.setLoadCallback(this.tag, ()=>{
-      clearTimeout(timer)
-      this.shouldInterceptLoad = false
+    webViewTurboModule.setLoadCallback(lockIdentifier, ()=>{
       Logger.debug(TAG, "call setLoadCallback")
+      clearTimeout(this.callLoadTimer)
+      this.shouldInterceptLoad = false
       if (this.html != "") {
         try {
           this.controller.loadData(
@@ -384,7 +387,7 @@ export struct RNCWebView {
           Logger.error(TAG, "error: " + error)
         }
       } else if (this.source.uri != "") {
-        Logger.debug(TAG, `[RNOH] newDescriptor props update uri: ` + this.source.uri);
+        Logger.debug(TAG, `uri: ` + this.source.uri);
         this.controller.loadUrl(this.descriptorWrapper.rawProps.newSource.uri, this.headers)
       }
     })
@@ -395,6 +398,15 @@ export struct RNCWebView {
   onOverrideUrlLoading(event: WebResourceRequest) {
     this.webViewBaseOperate?.emitShouldStartLoadWithRequestOverrideUrlLoading(event)
     return false
+  }
+
+  resetIntercept() {
+    Logger.debug(TAG,"resetIntercept")
+    this.ctx.rnInstance.getUITurboModule<WebViewTurboModule>(TM.RNCWebViewModule.NAME)
+      .clearLoadFunction(this.webViewBaseOperate?.getLockIdentifier())
+    clearTimeout(this.callLoadTimer)
+    this.shouldInterceptLoad = true
+    this.webViewBaseOperate?.setLockIdentifier(BaseOperate.generateLockIdentifier())
   }
 
   build() {
@@ -480,7 +492,7 @@ export struct RNCWebView {
       this.html = this.source.html
       if (this.controllerAttached) {
         try {
-          this.shouldInterceptLoad = true
+          this.resetIntercept()
           this.controller.loadData(
             this.source.html,
             "text/html",
@@ -496,7 +508,7 @@ export struct RNCWebView {
       Logger.debug(TAG, `[RNOH] newDescriptor props update uri: ` + this.source.uri);
       this.url = this.source.uri as string;
       if (this.controllerAttached) {
-        this.shouldInterceptLoad = true
+        this.resetIntercept()
         this.controller.loadUrl(this.descriptorWrapper.rawProps.newSource.uri, this.headers)
       }
     }
@@ -567,14 +579,14 @@ export struct RNCWebView {
             let result: WebViewEventParams = this.createWebViewEvent("onMessage")
             if (result) {
               result.data = data.toString()
-              result.lockIdentifier = ZERO
+              result.lockIdentifier = this.webViewBaseOperate?.getLockIdentifier()
               this.eventEmitter!.emit("message", result as ResultType);
             }
           }
         }
       };
       this.controller.registerJavaScriptProxy(bridge, JAVASCRIPT_INTERFACE, ["postMessage"])
-      this.shouldInterceptLoad = true
+      this.resetIntercept()
       this.source.uri ?
       this.controller.loadUrl(this.source.uri, this.headers) : this.controller.refresh()
       this.hasRegisterJavaScriptProxy = true

--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -25,7 +25,7 @@
 import { RNComponentContext } from '@rnoh/react-native-openharmony';
 import webview from '@ohos.web.webview';
 import { url as OSUrl } from '@kit.ArkTS';
-import { RNC } from '@rnoh/react-native-openharmony/generated';
+import { RNC, TM } from '@rnoh/react-native-openharmony/generated';
 import Logger from './Logger';
 import { BaseOperate } from './WebViewBaseOperate';
 import {
@@ -45,6 +45,7 @@ import {
   REFRESH_OFFSET,
   MINHEIGHT,
 } from './Magic';
+import { WebViewTurboModule } from './WebViewTurboModule';
 import { bundleManager } from '@kit.AbilityKit';
 
 export const TAG = "WebView"
@@ -97,6 +98,8 @@ export struct RNCWebView {
   private cleanUpCallbacks: (() => void)[] = []
   private descriptorWrapper: WebViewDescriptor = Object() as WebViewDescriptor
   private webViewBaseOperate: BaseOperate | null = null
+  private shouldInterceptLoad: boolean = true
+  static readonly SHOULD_OVERRIDE_URL_LOADING_TIMEOUT: number = 250
 
   aboutToAppear() {
     try {
@@ -261,7 +264,7 @@ export struct RNCWebView {
   controllerAttachedInit(): void {
     this.controllerAttached = true;
     this.eventEmitter = new RNC.RNCWebView.EventEmitter(this.ctx.rnInstance, this.tag)
-    this.webViewBaseOperate = new BaseOperate(this.eventEmitter, this.controller)
+    this.webViewBaseOperate = new BaseOperate(this.tag, this.eventEmitter, this.controller)
     this.webViewBaseOperate.setCustomUserAgent(this.descriptorWrapper.rawProps.userAgent,
       this.descriptorWrapper.rawProps.applicationNameForUserAgent)
     this.webViewBaseOperate.setFraudulentWebsiteWarningEnabled(this.descriptorWrapper.rawProps.fraudulentWebsiteWarningEnabled)
@@ -269,6 +272,7 @@ export struct RNCWebView {
     let uri = this.source.uri
     if (this.source.html != undefined && this.source.html != "") {
       try {
+        this.shouldInterceptLoad = true
         this.controller.loadData(
           this.source.html,
           "text/html",
@@ -280,8 +284,10 @@ export struct RNCWebView {
         Logger.error(TAG, "error:" + error)
       }
     } else if (uri != undefined && uri != "") {
+      this.shouldInterceptLoad = true
       this.controller.loadUrl(uri, this.headers);
     } else {
+      this.shouldInterceptLoad = true
       this.controller.loadUrl(uri, this.headers);
     }
     if (!this.hasRegisterJavaScriptProxy) {
@@ -352,8 +358,38 @@ export struct RNCWebView {
   }
 
   onLoadIntercept(event: OnLoadInterceptEvent): boolean {
+    if (!this.shouldInterceptLoad) {
+      return false
+    }
+
+    let webViewTurboModule = this.ctx.rnInstance.getUITurboModule<WebViewTurboModule>(TM.RNCWebViewModule.NAME)
+    let timer = setTimeout(()=>{
+      webViewTurboModule.callLoadFunction(this.tag)
+    }, RNCWebView.SHOULD_OVERRIDE_URL_LOADING_TIMEOUT)
+
+    webViewTurboModule.setLoadCallback(this.tag, ()=>{
+      clearTimeout(timer)
+      this.shouldInterceptLoad = false
+      Logger.debug(TAG, "call setLoadCallback")
+      if (this.html != "") {
+        try {
+          this.controller.loadData(
+            this.source.html,
+            "text/html",
+            "UTF-8",
+            this.source.baseUrl,
+            " "
+          );
+        } catch (error) {
+          Logger.error(TAG, "error: " + error)
+        }
+      } else if (this.source.uri != "") {
+        Logger.debug(TAG, `[RNOH] newDescriptor props update uri: ` + this.source.uri);
+        this.controller.loadUrl(this.descriptorWrapper.rawProps.newSource.uri, this.headers)
+      }
+    })
     this.webViewBaseOperate?.emitShouldStartLoadWithRequest(event)
-    return false
+    return true
   }
 
   onOverrideUrlLoading(event: WebResourceRequest) {
@@ -444,6 +480,7 @@ export struct RNCWebView {
       this.html = this.source.html
       if (this.controllerAttached) {
         try {
+          this.shouldInterceptLoad = true
           this.controller.loadData(
             this.source.html,
             "text/html",
@@ -459,6 +496,7 @@ export struct RNCWebView {
       Logger.debug(TAG, `[RNOH] newDescriptor props update uri: ` + this.source.uri);
       this.url = this.source.uri as string;
       if (this.controllerAttached) {
+        this.shouldInterceptLoad = true
         this.controller.loadUrl(this.descriptorWrapper.rawProps.newSource.uri, this.headers)
       }
     }
@@ -536,6 +574,7 @@ export struct RNCWebView {
         }
       };
       this.controller.registerJavaScriptProxy(bridge, JAVASCRIPT_INTERFACE, ["postMessage"])
+      this.shouldInterceptLoad = true
       this.source.uri ?
       this.controller.loadUrl(this.source.uri, this.headers) : this.controller.refresh()
       this.hasRegisterJavaScriptProxy = true

--- a/harmony/rn_webview/src/main/ets/RNCWebViewPackage.ts
+++ b/harmony/rn_webview/src/main/ets/RNCWebViewPackage.ts
@@ -26,13 +26,32 @@ import type {
   DescriptorWrapperFactoryByDescriptorType,
   DescriptorWrapperFactoryByDescriptorTypeCtx,
 } from '@rnoh/react-native-openharmony/ts';
-import { RNPackage } from '@rnoh/react-native-openharmony/ts';
-import { RNC } from '@rnoh/react-native-openharmony/generated/ts';
+import { RNPackage, UITurboModuleFactory, UITurboModule } from '@rnoh/react-native-openharmony/ts';
+import { RNC, TM } from '@rnoh/react-native-openharmony/generated/ts';
+import { WebViewTurboModule } from './WebViewTurboModule'
+import { UITurboModuleContext } from '@rnoh/react-native-openharmony/src/main/ets/RNOH/RNOHContext';
 
 export class RNCWebViewPackage extends RNPackage {
   createDescriptorWrapperFactoryByDescriptorType(ctx: DescriptorWrapperFactoryByDescriptorTypeCtx): DescriptorWrapperFactoryByDescriptorType {
     return {
       [RNC.RNCWebView.NAME]: (ctx) => new RNC.RNCWebView.DescriptorWrapper(ctx.descriptor)
     }
+  }
+
+  createUITurboModuleFactory(ctx: UITurboModuleContext): UITurboModuleFactory {
+    return new WebViewTurboModulesFactory(ctx);
+  }
+}
+
+class WebViewTurboModulesFactory extends UITurboModuleFactory {
+  createTurboModule(name: string): UITurboModule | null {
+    if (name === TM.RNCWebViewModule.NAME) {
+      return new WebViewTurboModule(this.ctx);
+    }
+    return null;
+  }
+
+  hasTurboModule(name: string): boolean {
+    return name === TM.RNCWebViewModule.NAME;
   }
 }

--- a/harmony/rn_webview/src/main/ets/WebViewBaseOperate.ets
+++ b/harmony/rn_webview/src/main/ets/WebViewBaseOperate.ets
@@ -19,9 +19,10 @@ interface CreateWebViewEventInterface {
 export class BaseOperate {
   private eventEmitter: RNC.RNCWebView.EventEmitter
   private controller: webview.WebviewController
-  private title: string = ''
+  private tag: number
 
-  constructor(eventEmitter: RNC.RNCWebView.EventEmitter, controller: webview.WebviewController) {
+  constructor(tag: number, eventEmitter: RNC.RNCWebView.EventEmitter, controller: webview.WebviewController) {
+    this.tag = tag
     this.eventEmitter = eventEmitter
     this.controller = controller
   }
@@ -52,7 +53,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: 0,
+        lockIdentifier: this.tag,
         progress: params.progress / ONE_HUNDRED
       })
     } catch (error) {
@@ -68,7 +69,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: 0,
+        lockIdentifier: this.tag,
         navigationType: "other",
         mainDocumentURL: ""
       })
@@ -85,7 +86,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: 0,
+        lockIdentifier: this.tag,
         navigationType: "other",
         mainDocumentURL: ""
       })
@@ -106,7 +107,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: 0,
+        lockIdentifier: this.tag,
         domain: "",
         code: event.error.getErrorCode(),
         description: event.error.getErrorInfo()
@@ -124,7 +125,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: 0,
+        lockIdentifier: this.tag,
         description: event.response.getResponseData(),
         statusCode: event.response.getResponseCode()
       })
@@ -159,7 +160,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: 0,
+        lockIdentifier: this.tag,
         navigationType: "other",
         mainDocumentURL: "",
         isTopFrame: false
@@ -177,7 +178,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: 0,
+        lockIdentifier: this.tag,
         navigationType: "other",
         mainDocumentURL: "",
         isTopFrame: false

--- a/harmony/rn_webview/src/main/ets/WebViewBaseOperate.ets
+++ b/harmony/rn_webview/src/main/ets/WebViewBaseOperate.ets
@@ -17,14 +17,15 @@ interface CreateWebViewEventInterface {
 }
 
 export class BaseOperate {
+  private static LOCK_IDENTIFIER = 0
   private eventEmitter: RNC.RNCWebView.EventEmitter
   private controller: webview.WebviewController
-  private tag: number
+  private lockIdentifier: number = 0
 
-  constructor(tag: number, eventEmitter: RNC.RNCWebView.EventEmitter, controller: webview.WebviewController) {
-    this.tag = tag
+  constructor(eventEmitter: RNC.RNCWebView.EventEmitter, controller: webview.WebviewController) {
     this.eventEmitter = eventEmitter
     this.controller = controller
+    this.lockIdentifier = BaseOperate.generateLockIdentifier()
   }
 
   static setThirdPartyCookiesEnabled(status: boolean) {
@@ -45,6 +46,19 @@ export class BaseOperate {
     }
   }
 
+  static generateLockIdentifier(): number {
+    BaseOperate.LOCK_IDENTIFIER =  BaseOperate.LOCK_IDENTIFIER + 1
+    return BaseOperate.LOCK_IDENTIFIER
+  }
+
+  getLockIdentifier():number {
+    return this.lockIdentifier
+  }
+
+  setLockIdentifier(lockIdentifier: number) {
+    this.lockIdentifier = lockIdentifier
+  }
+
   emitProgressChange(params: ProgressInterface) {
     try {
       this.eventEmitter!.emit('loadingProgress', {
@@ -53,7 +67,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: this.tag,
+        lockIdentifier: this.lockIdentifier,
         progress: params.progress / ONE_HUNDRED
       })
     } catch (error) {
@@ -69,7 +83,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: this.tag,
+        lockIdentifier: this.lockIdentifier,
         navigationType: "other",
         mainDocumentURL: ""
       })
@@ -86,7 +100,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: this.tag,
+        lockIdentifier: this.lockIdentifier,
         navigationType: "other",
         mainDocumentURL: ""
       })
@@ -107,7 +121,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: this.tag,
+        lockIdentifier: this.lockIdentifier,
         domain: "",
         code: event.error.getErrorCode(),
         description: event.error.getErrorInfo()
@@ -125,7 +139,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: this.tag,
+        lockIdentifier: this.lockIdentifier,
         description: event.response.getResponseData(),
         statusCode: event.response.getResponseCode()
       })
@@ -160,7 +174,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: this.tag,
+        lockIdentifier: this.lockIdentifier,
         navigationType: "other",
         mainDocumentURL: "",
         isTopFrame: false
@@ -178,7 +192,7 @@ export class BaseOperate {
         title: this.controller.getTitle(),
         canGoBack: this.controller.accessBackward(),
         canGoForward: this.controller.accessForward(),
-        lockIdentifier: this.tag,
+        lockIdentifier: this.lockIdentifier,
         navigationType: "other",
         mainDocumentURL: "",
         isTopFrame: false

--- a/harmony/rn_webview/src/main/ets/WebViewTurboModule.ts
+++ b/harmony/rn_webview/src/main/ets/WebViewTurboModule.ts
@@ -1,0 +1,27 @@
+import { UITurboModule } from '@rnoh/react-native-openharmony/ts';
+import { TM } from '@rnoh/react-native-openharmony/generated/ts';
+
+export class WebViewTurboModule extends UITurboModule implements TM.RNCWebViewModule.Spec {
+  private loadCallbackMap : Map<number,()=> void> = new Map();
+
+  isFileUploadSupported(): Promise<boolean> {
+    return Promise.resolve(true)
+  }
+
+  shouldStartLoadWithLockIdentifier(shouldStart: boolean, lockIdentifier: number): void {
+    if (shouldStart) {
+      this.callLoadFunction(lockIdentifier)
+    }else {
+      this.loadCallbackMap.delete(lockIdentifier)
+    }
+  }
+
+  setLoadCallback(tag:number, cb: ()=> void) {
+    this.loadCallbackMap.set(tag,cb)
+  }
+
+  callLoadFunction(tag:number){
+    this.loadCallbackMap.get(tag)?.()
+    this.loadCallbackMap.delete(tag)
+  }
+}

--- a/harmony/rn_webview/src/main/ets/WebViewTurboModule.ts
+++ b/harmony/rn_webview/src/main/ets/WebViewTurboModule.ts
@@ -1,5 +1,8 @@
 import { UITurboModule } from '@rnoh/react-native-openharmony/ts';
 import { TM } from '@rnoh/react-native-openharmony/generated/ts';
+import Logger from './Logger';
+
+const TAG = "WebViewTurboModule"
 
 export class WebViewTurboModule extends UITurboModule implements TM.RNCWebViewModule.Spec {
   private loadCallbackMap : Map<number,()=> void> = new Map();
@@ -9,19 +12,26 @@ export class WebViewTurboModule extends UITurboModule implements TM.RNCWebViewMo
   }
 
   shouldStartLoadWithLockIdentifier(shouldStart: boolean, lockIdentifier: number): void {
+    Logger.debug(TAG,`shouldStartLoadWithLockIdentifier shouldStart:${shouldStart},lockIdentifier:${lockIdentifier}`)
     if (shouldStart) {
       this.callLoadFunction(lockIdentifier)
     }else {
-      this.loadCallbackMap.delete(lockIdentifier)
+      this.clearLoadFunction(lockIdentifier)
     }
   }
 
-  setLoadCallback(tag:number, cb: ()=> void) {
-    this.loadCallbackMap.set(tag,cb)
+  setLoadCallback(lockIdentifier:number, cb: ()=> void) {
+    this.loadCallbackMap.set(lockIdentifier,cb)
   }
 
-  callLoadFunction(tag:number){
-    this.loadCallbackMap.get(tag)?.()
-    this.loadCallbackMap.delete(tag)
+  callLoadFunction(lockIdentifier:number){
+    Logger.debug(TAG,`callLoadFunction function:${JSON.stringify(this.loadCallbackMap.get(lockIdentifier))}`)
+    this.loadCallbackMap.get(lockIdentifier)?.()
+    this.clearLoadFunction(lockIdentifier)
+  }
+
+  clearLoadFunction(lockIdentifier:number){
+    Logger.debug(TAG,`clearLoadFunction lockIdentifier:${lockIdentifier} `)
+    this.loadCallbackMap.delete(lockIdentifier)
   }
 }

--- a/src/NativeRNCWebViewModule.ts
+++ b/src/NativeRNCWebViewModule.ts
@@ -1,0 +1,13 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+import { Double } from 'react-native/Libraries/Types/CodegenTypes';
+
+export interface Spec extends TurboModule {
+  isFileUploadSupported(): Promise<boolean>;
+  shouldStartLoadWithLockIdentifier(
+    shouldStart: boolean,
+    lockIdentifier: Double
+  ): void;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('RNCWebViewModule');

--- a/src/WebView.harmony.tsx
+++ b/src/WebView.harmony.tsx
@@ -5,10 +5,10 @@ import React, {
   useRef
 } from 'react';
 import { Image, View, ImageSourcePropType, HostComponent } from 'react-native';
-import { Double } from 'react-native/Libraries/Types/CodegenTypes';
 import invariant from 'invariant';
 
 import RNCWebView, { Commands, NativeProps } from './RNCWebViewNativeComponent';
+import RNCWebViewModule from './NativeRNCWebViewModule';
 
 import {
   defaultOriginWhitelist,
@@ -45,11 +45,6 @@ const useWarnIfChanges = <T extends unknown>(value: T, name: string) => {
     ref.current = value;
   }
 };
-
-const shouldStartLoadWithLockIdentifier: (
-  shouldStart: boolean,
-  lockIdentifier: Double
-) => void = () => { }
 
 const WebViewComponent = forwardRef<{}, IOSWebViewProps & { scalesPageToFit: boolean, minimumFontSize: number, thirdPartyCookiesEnabled: boolean, geolocationEnabled: boolean }>(
   (
@@ -113,7 +108,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps & { scalesPageToFit: boo
 
     const onShouldStartLoadWithRequestCallback = useCallback(
       (shouldStart: boolean, _url: string, lockIdentifier = 0) => {
-        shouldStartLoadWithLockIdentifier(
+        RNCWebViewModule.shouldStartLoadWithLockIdentifier(
           shouldStart,
           lockIdentifier
         );


### PR DESCRIPTION
# Summary

#249 

安卓onShouldStartLoadWithRequest实现方案：
1. 原生shouldOverrideUrlLoading拦截加载请求
2. 发送onShouldStartLoadWithRequest事件
3. 设置250ms超时保护，注释主线程去获取子线程TM中的结果
4. js 业务侧返回拦截结果，并设置到TM中
5. shouldOverrideUrlLoading 根据进行是否拦截
[相关代码 ](https://github.com/react-native-webview/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java)

由于在RNOH中，emitComponentEvent是异步接口，如果按照类似实现在阻塞主线程时arkui没有发送VSync，而无法真正发送事件至js线程触发RN onShouldStartLoadWithRequest事件，因此在HarmonyOS中使用如下实现方案

HarmonyOS onShouldStartLoadWithRequest实现方案：
1. 原生onLoadIntercept拦截加载请求
2. 发送onShouldStartLoadWithRequest事件，设置正常加载时的回调，设置250ms超时保护超时必定加载网页
3. onLoadIntercept必定拦截加载
4. 待js返回结果后，在shouldStartLoadWithLockIdentifier TM中根据结果确定是否加载，并执行相关回调
5. onLoadIntercept不在拦截

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

import React, { useState } from 'react';
import { View, Button, StyleSheet } from 'react-native';
import { WebView } from 'react-native-webview';

const WebViewDemo = () => {
  const [url, setUrl] = useState('https://www.example.com');
  WebView.isFileUploadSupported().then(res=>{
    console.log("isFileUploadSupported:",res)
  })
  return (
    <View style={styles.container}>
  <WebView
  style={{width:'100%',height:'300'}}
  source={{ uri: 'https://www.baidu.com' }}
  onShouldStartLoadWithRequest={(request) => {
    // Only allow navigating within this website
    return false
  }}
  onLoadEnd={()=>
    console.log('end')
  }
/>
<WebView
  style={{width:'100%',height:'300'}}
  source={{ uri: url }}
  onShouldStartLoadWithRequest={(request) => {
    // Only allow navigating within this website
    console.log(request)
    return request.url.startsWith('https://reactnative.dev');
  }}
  onLoadEnd={()=>
    console.log('end')
  }
/>
<Button title='11111' onPress={()=>{
  setUrl('https://reactnative.dev')
  setTimeout(() => {
  setUrl('https://www.baidu.com')
  }, 0);
}}></Button>
    </View>
  );
};

const styles = StyleSheet.create({
  container: {
    width: '100%',
    height: '100%'
  },
  webview: {
    flex: 1,
    marginTop: 10,
  },
  loading: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});

export default WebViewDemo;


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)


