### PR TITLE
fix: 修改TYPE_SENSOR权限不需要弹框；合入13.10.2-rc.0.2.35修改到sig分支

### DIFF
--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -24,7 +24,7 @@
 
 import { RNComponentContext } from '@rnoh/react-native-openharmony';
 import webview from '@ohos.web.webview';
-import { url as OSUrl } from '@kit.ArkTS';
+import { url as OSUrl, url } from '@kit.ArkTS';
 import { RNC, TM } from '@rnoh/react-native-openharmony/generated';
 import Logger from './Logger';
 import { BaseOperate } from './WebViewBaseOperate';
@@ -360,6 +360,19 @@ export struct RNCWebView {
   onLoadIntercept(event: OnLoadInterceptEvent): boolean {
     Logger.debug(TAG, `onLoadIntercept request url:${event.data.getRequestUrl()} ,shouldInterceptLoad:${this.shouldInterceptLoad}`)
     if (!this.shouldInterceptLoad) {
+      try {
+        // 避免链接多一个/字符导致判断错误
+        if (url.URL.parseURL(event.data.getRequestUrl()).toString() != url.URL.parseURL(this.url.toString()).toString()) {
+          this.webViewBaseOperate?.setLockIdentifier(BaseOperate.generateLockIdentifier())
+          this.webViewBaseOperate?.emitShouldStartLoadWithRequest(event)
+          // 非网络链接拦截加载
+          if ( !["https:","http:"].includes(new url.URL(event.data.getRequestUrl()).protocol)) {
+            return true
+          }
+        }
+      } catch (e) {
+        Logger.debug(TAG, "onLoadIntercept error:" + e)
+      }
       return false
     }
 
@@ -414,7 +427,7 @@ export struct RNCWebView {
       Web({ src: "", controller: this.controller, renderMode: this.renderMode })
         .mixedMode(this.mode)
         .onPermissionRequest((event: OnPermissionRequestEvent) => {
-          if (event) {
+          if (event && (this.getPermissionDialogMessage(event) != "TYPE_SENSOR")) {
             AlertDialog.show({
               title: this.resourceToString($r('app.string.on_confirm')) + event.request.getOrigin(),
               message: this.getPermissionDialogMessage(event),


### PR DESCRIPTION

# Summary
fix: 修改TYPE_SENSOR权限不需要弹框；合入13.10.2-rc.0.2.35修改到sig分支


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

