### PR TITLE
fix: 合入13.10.2-0.2.35背景色修改到rc分支，并添加TYPE_SENSOR权限不进行弹框

### DIFF
--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -428,7 +428,7 @@ export struct RNCWebView {
       Web({ src: "", controller: this.controller, renderMode: this.renderMode })
         .mixedMode(this.mode)
         .onPermissionRequest((event: OnPermissionRequestEvent) => {
-          if (event) {
+          if (event && (this.getPermissionDialogMessage(event) != "TYPE_SENSOR")) {
             AlertDialog.show({
               title: this.resourceToString($r('app.string.on_confirm')) + event.request.getOrigin(),
               message: this.getPermissionDialogMessage(event),
@@ -463,6 +463,7 @@ export struct RNCWebView {
         .verticalScrollBarAccess(this.descriptorWrapper.rawProps.showsVerticalScrollIndicator)
         .overviewModeAccess(this.descriptorWrapper.rawProps.scalesPageToFit)
         .textZoomRatio(this.descriptorWrapper.rawProps.textZoom)
+        .backgroundColor(BaseOperate.getColorMode(this.ctx.uiAbilityContext, this.descriptorWrapper.rawProps.forceDarkOn) === WebDarkMode.On ? Color.White : Color.Transparent)
         .darkMode(BaseOperate.getColorMode(this.ctx.uiAbilityContext, this.descriptorWrapper.rawProps.forceDarkOn))
         .forceDarkAccess(this.forceDark)
         .cacheMode(this.cacheMode)


### PR DESCRIPTION

# Summary

fix: 合入13.10.2-0.2.35背景色修改到rc分支，并添加TYPE_SENSOR权限不进行弹框


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

