### PR TITLE
feat:合入rc.0.2.36版本添加TYPE_SENSOR权限不进行弹框的修改到sig分支

### DIFF
--- a/harmony/rn_webview/src/main/ets/RNCWebView.ets
+++ b/harmony/rn_webview/src/main/ets/RNCWebView.ets
@@ -414,7 +414,7 @@ export struct RNCWebView {
       Web({ src: "", controller: this.controller, renderMode: this.renderMode })
         .mixedMode(this.mode)
         .onPermissionRequest((event: OnPermissionRequestEvent) => {
-          if (event) {
+          if (event && (this.getPermissionDialogMessage(event) != "TYPE_SENSOR")) {
             AlertDialog.show({
               title: this.resourceToString($r('app.string.on_confirm')) + event.request.getOrigin(),
               message: this.getPermissionDialogMessage(event),


### PR DESCRIPTION

# Summary

feat:合入rc.0.2.36版本添加TYPE_SENSOR权限不进行弹框的修改到sig分支

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
